### PR TITLE
Added Hat and Corkscrew

### DIFF
--- a/gear_list.md
+++ b/gear_list.md
@@ -14,4 +14,6 @@
 * Other stuff
  * Fork
  * Knife
- * Fork
+ * Corkscrew
+ * Hat
+	


### PR DESCRIPTION
Change list items to include two missing essentials.

These complete camping list should always contain a hat and a corkscrew, based on experience.

Please review these additions to the list - let me know if you agree.

@jav094 if you could review this list before the end of the week that would be great
